### PR TITLE
ci: cache npm and test gitbook build in PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ dist: trusty
 language: node_js
 node_js:
   - 12
-
-branches:
-  only:
-  - master
+cache: npm
 
 before_script:
   - npm install gitbook-cli -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ node_js:
 cache: npm
 
 before_script:
-  - npm install gitbook-cli -g
+  - npm install gitbook-cli
+  - export PATH=$(npm bin):$PATH
 
 script:
   - gitbook build .


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

The gitbook package can be cached and the build should trigger for every PR.
