### PR TITLE
Remove tidb_batch_insert related instructions

### DIFF
--- a/session4/chapter6/transaction-statement-count-limit.md
+++ b/session4/chapter6/transaction-statement-count-limit.md
@@ -221,10 +221,6 @@ CREATE TABLE `t1` (
 
 官方提供内部 Batch 的方法来绕过大事务的限制，分别由三个参数来控制：
 
-- tidb_batch_insert
-
-> 作用域: SESSION 默认值: 0 这个变量用来设置是否自动切分插入数据。仅在 Autocommit 开启时有效。 当插入大量数据时，可以将其设置为 True，这样插入数据会被自动切分为多个 Batch，每个 Batch 使用一个单独的事务进行插入。
-
 - tidb_batch_delete
 
 > 作用域: SESSION 默认值: 0 这个变量用来设置是否自动切分待删除的数据。仅在 Autocommit 开启时有效。 当删除大量数据时，可以将其设置为 True，这样待删除数据会被自动切分为多个 Batch，每个 Batch 使用一个单独的事务进行删除。


### PR DESCRIPTION
4.0.2 This parameter has expired, and the other two parameters have been confirmed to see if they need to be removed. The official method is not currently recommended.Moreover, there is a conflict with the above "4.0 Major Affairs" chapter,

Help evaluate.

<!--
Thank you for contributing to TiDB in Action!
-->

### What problem does this PR solve? <!--add the issue link with a summary if it exists, create the issue if it not exist-->

### How to contact you? <!--Please leave contact information, it is optional-->
- Email:
- Telephone:
- WeChat:
- Others: